### PR TITLE
M3 issue and development

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,60 +1,39 @@
-# Nuxt Starter Template
+# Hacker News Reader（Nuxt 4）
 
-[![Nuxt UI](https://img.shields.io/badge/Made%20with-Nuxt%20UI-00DC82?logo=nuxt&labelColor=020420)](https://ui.nuxt.com)
+記事を読む体験を中心にした Hacker News リーダーです。
 
-Use this template to get started with [Nuxt UI](https://ui.nuxt.com) quickly.
+## 開発環境
 
-- [Live demo](https://starter-template.nuxt.dev/)
-- [Documentation](https://ui.nuxt.com/docs/getting-started/installation/nuxt)
+- Node: `22`
+- Package manager: `pnpm`（`package.json` の `packageManager` に従う）
 
-<a href="https://starter-template.nuxt.dev/" target="_blank">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://ui.nuxt.com/assets/templates/nuxt/starter-dark.png">
-    <source media="(prefers-color-scheme: light)" srcset="https://ui.nuxt.com/assets/templates/nuxt/starter-light.png">
-    <img alt="Nuxt Starter Template" src="https://ui.nuxt.com/assets/templates/nuxt/starter-light.png">
-  </picture>
-</a>
-
-> The starter template for Vue is on https://github.com/nuxt-ui-templates/starter-vue.
-
-## Quick Start
-
-```bash [Terminal]
-npm create nuxt@latest -- -t github:nuxt-ui-templates/starter
-```
-
-## Deploy your own
-
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-name=starter&repository-url=https%3A%2F%2Fgithub.com%2Fnuxt-ui-templates%2Fstarter&demo-image=https%3A%2F%2Fui.nuxt.com%2Fassets%2Ftemplates%2Fnuxt%2Fstarter-dark.png&demo-url=https%3A%2F%2Fstarter-template.nuxt.dev%2F&demo-title=Nuxt%20Starter%20Template&demo-description=A%20minimal%20template%20to%20get%20started%20with%20Nuxt%20UI.)
-
-## Setup
-
-Make sure to install the dependencies:
+## セットアップ
 
 ```bash
-pnpm install
+pnpm install --frozen-lockfile
 ```
 
-## Development Server
-
-Start the development server on `http://localhost:3000`:
+## ローカル開発
 
 ```bash
 pnpm dev
 ```
 
-## Production
+起動後は `http://localhost:3000` を開きます。
 
-Build the application for production:
-
-```bash
-pnpm build
-```
-
-Locally preview production build:
+## テスト
 
 ```bash
-pnpm preview
+pnpm test
 ```
 
-Check out the [deployment documentation](https://nuxt.com/docs/getting-started/deployment) for more information.
+## CIのローカル再現
+
+CIは下記を実行します（詳細は `spec/ci.md` 参照）:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm run lint
+pnpm run typecheck
+pnpm run build
+```

--- a/app/components/CommentNode.vue
+++ b/app/components/CommentNode.vue
@@ -1,0 +1,57 @@
+<template>
+  <div
+    class="py-3"
+    :class="levelClass"
+  >
+    <div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-(--ui-text-muted)">
+      <span v-if="node.by">by {{ node.by }}</span>
+      <span v-else>by [deleted]</span>
+      <span>·</span>
+      <span>{{ formatRelativeTimeFromUnixSeconds(node.time) }}</span>
+    </div>
+
+    <div class="mt-2 text-sm leading-relaxed">
+      <div
+        v-if="node.text"
+        class="prose prose-sm max-w-none"
+        v-html="node.text"
+      />
+      <p v-else class="text-(--ui-text-muted)">
+        （このコメントは削除されました）
+      </p>
+    </div>
+
+    <div
+      v-if="node.kids.length > 0"
+      class="mt-3 grid gap-3"
+    >
+      <CommentNode
+        v-for="kid in node.kids"
+        :key="kid.id"
+        :node="kid"
+        :level="level + 1"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { CommentNode } from '~/types/api'
+import { computed } from 'vue'
+import { formatRelativeTimeFromUnixSeconds } from '~/utils/format'
+
+defineOptions({ name: 'CommentNode' })
+
+const props = withDefaults(defineProps<{
+  node: CommentNode
+  level?: number
+}>(), {
+  level: 1
+})
+
+const levelClass = computed(() => {
+  if (props.level <= 1) return ''
+  return 'pl-4 border-l border-(--ui-border-muted)'
+})
+</script>
+

--- a/app/components/CommentNode.vue
+++ b/app/components/CommentNode.vue
@@ -11,14 +11,19 @@
     </div>
 
     <div class="mt-2 text-sm leading-relaxed">
+      <!-- eslint-disable vue/no-v-html -->
       <div
         v-if="node.text"
         class="prose prose-sm max-w-none"
         v-html="node.text"
       />
-      <p v-else class="text-(--ui-text-muted)">
+      <p
+        v-else
+        class="text-(--ui-text-muted)"
+      >
         （このコメントは削除されました）
       </p>
+      <!-- eslint-enable vue/no-v-html -->
     </div>
 
     <div
@@ -54,4 +59,3 @@ const levelClass = computed(() => {
   return 'pl-4 border-l border-(--ui-border-muted)'
 })
 </script>
-

--- a/app/composables/useItem.ts
+++ b/app/composables/useItem.ts
@@ -1,7 +1,38 @@
 import type { ItemResponse } from '~/types/api'
 import type { MaybeRefOrGetter } from 'vue'
-import { toValue } from 'vue'
+import { computed, toValue } from 'vue'
 
 export function useItem(id: MaybeRefOrGetter<number | string>) {
   return useFetch<ItemResponse>(() => `/api/item/${toValue(id)}`)
+}
+
+type UseItemCommentsOptions = {
+  maxComments?: number
+  maxDepth?: number
+}
+
+/**
+ * Lazy-load comments for an item.
+ *
+ * Note: This is intentionally `immediate: false` so the caller can trigger
+ * fetching only after the user expands the comments section.
+ */
+export function useItemComments(
+  id: MaybeRefOrGetter<number | string>,
+  options?: UseItemCommentsOptions
+) {
+  const maxComments = options?.maxComments ?? 50
+  const maxDepth = options?.maxDepth ?? 4
+
+  const query = computed(() => ({
+    includeComments: '1',
+    maxComments,
+    maxDepth
+  }))
+
+  return useFetch<ItemResponse>(() => `/api/item/${toValue(id)}`, {
+    immediate: false,
+    watch: false,
+    query
+  })
 }

--- a/server/api/item/[id].get.ts
+++ b/server/api/item/[id].get.ts
@@ -110,4 +110,18 @@ export default defineCachedEventHandler(async (event) => {
   }
 
   return response
-}, { maxAge: 120 })
+}, {
+  maxAge: 120,
+  getKey: (event) => {
+    const rawId = event.context.params?.id
+    const id = typeof rawId === 'string' ? rawId : String(rawId ?? '')
+
+    const query = getQuery(event)
+    const includeComments = query.includeComments === '1'
+    if (!includeComments) return `item:${id}`
+
+    const maxComments = parseIntParam(query.maxComments, 50, { min: 0, max: 200 })
+    const maxDepth = parseIntParam(query.maxDepth, 4, { min: 1, max: 10 })
+    return `item:${id}:comments:${maxComments}:${maxDepth}`
+  }
+})

--- a/server/utils/hn.ts
+++ b/server/utils/hn.ts
@@ -19,6 +19,43 @@ const HN_BASE = 'https://hacker-news.firebaseio.com/v0'
 
 export type HnStoriesType = 'top' | 'new' | 'best'
 
+type CacheEntry<T> = {
+  value: T
+  expiresAt: number
+}
+
+const STORY_IDS_TTL_MS = 30_000
+const ITEM_TTL_MS = 60_000
+const ITEM_CACHE_MAX = 2_000
+
+const storyIdsCache = new Map<HnStoriesType, CacheEntry<number[]>>()
+const itemCache = new Map<number, CacheEntry<HnItem | null>>()
+
+function getFromCache<K, V>(cache: Map<K, CacheEntry<V>>, key: K): V | undefined {
+  const entry = cache.get(key)
+  if (!entry) return undefined
+  if (Date.now() > entry.expiresAt) {
+    cache.delete(key)
+    return undefined
+  }
+  return entry.value
+}
+
+function setCache<K, V>(cache: Map<K, CacheEntry<V>>, key: K, value: V, ttlMs: number) {
+  cache.set(key, { value, expiresAt: Date.now() + ttlMs })
+}
+
+function pruneItemCache() {
+  if (itemCache.size <= ITEM_CACHE_MAX) return
+  const over = itemCache.size - ITEM_CACHE_MAX
+  let i = 0
+  for (const key of itemCache.keys()) {
+    itemCache.delete(key)
+    i++
+    if (i >= over) return
+  }
+}
+
 function storiesPath(type: HnStoriesType) {
   switch (type) {
     case 'top':
@@ -31,15 +68,28 @@ function storiesPath(type: HnStoriesType) {
 }
 
 export async function fetchStoryIds(type: HnStoriesType): Promise<number[]> {
+  const cached = getFromCache(storyIdsCache, type)
+  if (cached) return cached
+
   const ids = await $fetch<number[]>(`${HN_BASE}${storiesPath(type)}`)
-  return Array.isArray(ids) ? ids : []
+  const normalized = Array.isArray(ids) ? ids : []
+  setCache(storyIdsCache, type, normalized, STORY_IDS_TTL_MS)
+  return normalized
 }
 
 export async function fetchItem(id: number): Promise<HnItem | null> {
   if (!Number.isFinite(id) || id <= 0) return null
+
+  const cached = getFromCache(itemCache, id)
+  if (cached !== undefined) return cached
+
   const item = await $fetch<HnItem | null>(`${HN_BASE}/item/${id}.json`)
-  if (!item || typeof item !== 'object') return null
-  return item
+  const normalized = !item || typeof item !== 'object' ? null : item
+
+  setCache(itemCache, id, normalized, ITEM_TTL_MS)
+  pruneItemCache()
+
+  return normalized
 }
 
 export async function fetchItems(ids: readonly number[], concurrency = 10): Promise<(HnItem | null)[]> {

--- a/spec/development-plan.md
+++ b/spec/development-plan.md
@@ -49,14 +49,14 @@
 
 ### ルートルール / 生成（`routeRules`）の扱い（重要）
 
-このリポジトリは `nuxt.config.ts` に `routeRules` があり、`/` が `prerender: true` になっている。
+このリポジトリは `nuxt.config.ts` に `routeRules` があり、**MVPでは `/` を `prerender: false`（SSR）**としている。
 
 - HN は更新頻度が高いため、**一覧ページの完全プリレンダーは内容が古くなりやすい**。
 - 方針候補:
   - **SSR + サーバ側キャッシュ**（推奨）
   - もしくは `routeRules` を `swr` / `isr` 相当の戦略に寄せる（デプロイ環境に依存）
 
-※ MVP 段階では「SSR + `/api/*` の短期キャッシュ」を前提に設計する。
+※ MVP 段階では「SSR + `/api/*` の短期キャッシュ」を前提に設計する（更新目安: 1〜5分）。
 
 ### Composables（取得の統一）
 

--- a/spec/qa-checklist.md
+++ b/spec/qa-checklist.md
@@ -1,0 +1,35 @@
+# QA / 重要ケースのチェックリスト（最低限）
+
+目的: 壊れやすいケース（HN特有の欠損/例外）を見落とさないための最小チェック。
+
+## 一覧（`/` / `GET /api/stories`）
+
+- **type**
+  - `top/new/best` が動く
+  - 不正な `type` は `400` + `ApiError` 形式
+- **ページング**
+  - `page=1` で表示される
+  - 範囲外ページ（startIndex >= total）で `items: []` が返る
+- **欠損/除外**
+  - `dead/deleted` なitemが混ざっても壊れない（除外して埋める）
+  - `url` が無い（Ask/Show）場合でも表示は成立する（domainは `null`）
+
+## 詳細（`/item/[id]` / `GET /api/item/:id`）
+
+- **id**
+  - 不正なidは `400` + `ApiError`
+  - 存在しない/`dead/deleted` は `404` + `ApiError`
+- **url**
+  - `url` がある: Primary CTA「読む」が出る
+  - `url` がない: フォールバックの文言/導線が出る
+
+## コメント（`GET /api/item/:id?includeComments=1`）
+
+- **遅延ロード**
+  - デフォルトではコメント取得しない（折りたたみ）
+  - 開いたときだけ取得する
+- **制限**
+  - `maxComments` を超えて返さない
+  - `maxDepth` を超えて再帰取得しない
+  - `dead/deleted` コメントは除外される
+

--- a/tests/nuxt/item-page.test.ts
+++ b/tests/nuxt/item-page.test.ts
@@ -1,8 +1,10 @@
-import { describe, expect, it } from 'vitest'
-import { ref } from 'vue'
+import { describe, expect, it, vi } from 'vitest'
+import { nextTick, ref } from 'vue'
 import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
 
 import ItemPage from '~/pages/item/[id].vue'
+
+let refreshSpy: ReturnType<typeof vi.fn> | null = null
 
 mockNuxtImport('useRoute', () => {
   return () => ({ params: { id: '123' } })
@@ -29,10 +31,85 @@ mockNuxtImport('useItem', () => {
   }
 })
 
+mockNuxtImport('useItemComments', () => {
+  return () => {
+    const data = ref(null)
+    const pending = ref(false)
+    const error = ref(null)
+
+    refreshSpy = vi.fn(async () => {
+      data.value = {
+        item: {
+          id: 123,
+          title: 'Hello HN',
+          url: 'https://example.com',
+          by: 'alice',
+          time: 1700000000,
+          score: 42,
+          descendants: 10,
+          type: 'story'
+        },
+        comments: {
+          total: 10,
+          loaded: 1,
+          maxDepth: 4,
+          items: [
+            {
+              id: 1,
+              by: 'bob',
+              time: 1700000001,
+              text: '<p>first</p>',
+              kids: []
+            }
+          ]
+        }
+      }
+      pending.value = false
+      error.value = null
+    })
+
+    return { data, pending, error, refresh: refreshSpy }
+  }
+})
+
 describe('pages/item/[id]', () => {
   it('renders title and "読む" CTA', async () => {
     const wrapper = await mountSuspended(ItemPage)
     expect(wrapper.text()).toContain('Hello HN')
     expect(wrapper.text()).toContain('読む')
+  })
+
+  it('lazy-loads comments only after expanding', async () => {
+    const wrapper = await mountSuspended(ItemPage)
+
+    expect(wrapper.text()).toContain('コメントを表示')
+    expect(wrapper.text()).not.toContain('first')
+
+    const buttons = wrapper.findAll('button')
+    const showButton = buttons.find(b => b.text().includes('コメントを表示'))
+    expect(showButton).toBeTruthy()
+
+    await showButton!.trigger('click')
+    await nextTick()
+
+    expect(refreshSpy).not.toBeNull()
+    expect(refreshSpy!).toHaveBeenCalledTimes(1)
+    expect(wrapper.text()).toContain('bob')
+    expect(wrapper.text()).toContain('first')
+
+    const hideButton = wrapper.findAll('button').find(b => b.text().includes('コメントを隠す'))
+    expect(hideButton).toBeTruthy()
+
+    await hideButton!.trigger('click')
+    await nextTick()
+    expect(wrapper.text()).not.toContain('first')
+
+    const showAgain = wrapper.findAll('button').find(b => b.text().includes('コメントを表示'))
+    expect(showAgain).toBeTruthy()
+
+    await showAgain!.trigger('click')
+    await nextTick()
+    expect(refreshSpy!).toHaveBeenCalledTimes(1)
+    expect(wrapper.text()).toContain('first')
   })
 })

--- a/tests/nuxt/item-page.test.ts
+++ b/tests/nuxt/item-page.test.ts
@@ -3,6 +3,7 @@ import { nextTick, ref } from 'vue'
 import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
 
 import ItemPage from '~/pages/item/[id].vue'
+import type { ItemResponse } from '~/types/api'
 
 let refreshSpy: ReturnType<typeof vi.fn> | null = null
 
@@ -33,7 +34,7 @@ mockNuxtImport('useItem', () => {
 
 mockNuxtImport('useItemComments', () => {
   return () => {
-    const data = ref(null)
+    const data = ref<ItemResponse | null>(null)
     const pending = ref(false)
     const error = ref(null)
 

--- a/tests/server/utils.test.ts
+++ b/tests/server/utils.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import { extractDomain } from '../../server/utils/url'
+import { mapWithConcurrency } from '../../server/utils/concurrency'
+
+describe('server/utils/url.extractDomain', () => {
+  it('returns hostname for valid urls', () => {
+    expect(extractDomain('https://example.com/foo')).toBe('example.com')
+    expect(extractDomain('http://news.ycombinator.com/item?id=1')).toBe('news.ycombinator.com')
+  })
+
+  it('returns null for invalid/empty inputs', () => {
+    expect(extractDomain(null)).toBeNull()
+    expect(extractDomain(undefined)).toBeNull()
+    expect(extractDomain('')).toBeNull()
+    expect(extractDomain('not a url')).toBeNull()
+  })
+})
+
+describe('server/utils/concurrency.mapWithConcurrency', () => {
+  it('preserves order while running with concurrency', async () => {
+    const input = [1, 2, 3, 4, 5]
+    const out = await mapWithConcurrency(input, 2, async (n) => {
+      await new Promise(r => setTimeout(r, 1))
+      return n * 2
+    })
+    expect(out).toEqual([2, 4, 6, 8, 10])
+  })
+
+  it('throws for invalid concurrency', async () => {
+    await expect(mapWithConcurrency([1], 0, async n => n)).rejects.toThrow('Invalid concurrency')
+  })
+})


### PR DESCRIPTION
Close #17
Close #11
Close #13
Close #12

Implement M3: comment folding with lazy loading and optimized caching for item detail pages.

This fulfills the M3 development plan by adding a toggleable comment section that lazy-loads comments with depth/count limits, and optimizes caching for both story IDs and individual items (with separate cache keys for comments) to reduce API calls and improve performance.

---
<a href="https://cursor.com/background-agent?bcId=bc-daad0665-05a0-4db2-900a-f4f85a7f5806"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-daad0665-05a0-4db2-900a-f4f85a7f5806"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a toggleable comments section that is fetched on demand and rendered recursively.
> 
> - UI: Item page adds a comments panel with show/hide toggle, loading states, error handling, and renders via `CommentNode.vue` (recursive, handles deleted text and nesting)
> - Composables: New `useItemComments` to fetch comments lazily with `includeComments`, `maxComments`, `maxDepth` query params (`immediate: false`)
> - API: `server/api/item/[id].get.ts` now keys cache by `id` and comment query (`includeComments`, `maxComments`, `maxDepth`) to separate item-only vs comments-inclusive responses
> - Backend caching: `server/utils/hn.ts` adds in-memory caches for story IDs and items with TTL and pruning; `fetchStoryIds`/`fetchItem` now use cache
> - Tests: Adds `tests/nuxt/item-page.test.ts` covering lazy-load behavior and ensuring no refetch on re-expand
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5ae4db21b89bd445a98061a4d7712057c423a99. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->